### PR TITLE
ci: add reusable CI/CD workflow and deployment automation

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,130 @@
+name: Reusable CI/CD Workflow
+
+on:
+  workflow_call:
+    inputs:
+      project:
+        description: "Name of the project"
+        required: true
+        type: string
+      service_name:
+        description: "Name of the service"
+        required: true
+        type: string
+      env_code:
+        description: "Environment code (dev, stg, prod)"
+        required: true
+        type: string
+      environment:
+        description: "Environment name (Develop, Staging, Production)"
+        required: true
+        type: string
+      git_branch:
+        description: "Branch name (develop, main, …)"
+        required: true
+        type: string
+      aws_role_arn:
+        description: "AWS Role ARN for OIDC"
+        required: true
+        type: string
+      aws_region:
+        description: "AWS Region (e.g., eu-central-1, us-east-1)"
+        required: true
+        type: string
+      slack_mentions:
+        description: "Slack mentions for failure notifications"
+        required: false
+        type: string
+      slack_webhook_url:
+        description: "Slack Webhook URL for notifications"
+        required: true
+        type: string
+
+jobs:
+  build:
+    name: Build & Deploy ${{ inputs.service_name }}
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write
+      contents: read
+
+    concurrency:
+      group: ${{ inputs.service_name }}-${{ inputs.env_code }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    env:
+      ENV_CODE: ${{ inputs.env_code }}
+      AWS_REGION: ${{ inputs.aws_region }}
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ inputs.aws_role_arn }}
+          aws-region: ${{ inputs.aws_region }}
+
+      # 👉 Load env file from SSM
+      - name: Setup File Environment (.env from SSM)
+        run: |
+          aws ssm get-parameter \
+            --name "/tts/${{ env.ENV_CODE }}/${{ inputs.service_name }}/config/env-file" \
+            --with-decryption \
+            --region $AWS_REGION \
+            --query "Parameter.Value" \
+            --output text > .env
+          echo "✅ .env file loaded from SSM"
+
+      # 👉 Fetch Cloudflare credentials from AWS Secrets Manager
+      - name: Fetch Cloudflare credentials from Secrets Manager
+        id: cf-creds
+        run: |
+          SECRET_VALUE=$(aws secretsmanager get-secret-value \
+            --secret-id "geminigen-cloudflare-pages/credentials" \
+            --region $AWS_REGION \
+            --query SecretString \
+            --output text)
+          echo "$SECRET_VALUE" > cf_secret.json
+          CLOUDFLARE_ACCOUNT_ID=$(jq -r '.accountid' cf_secret.json)
+          CLOUDFLARE_API_TOKEN=$(jq -r '.apitoken' cf_secret.json)
+          CLOUDFLARE_ZONE_ID=$(jq -r '.zoneid' cf_secret.json)
+          echo "CLOUDFLARE_ACCOUNT_ID=$CLOUDFLARE_ACCOUNT_ID" >> $GITHUB_ENV
+          echo "CLOUDFLARE_API_TOKEN=$CLOUDFLARE_API_TOKEN" >> $GITHUB_ENV
+          echo "CLOUDFLARE_ZONE_ID=$CLOUDFLARE_ZONE_ID" >> $GITHUB_ENV
+          rm -f cf_secret.json
+
+      - name: Deploy to Cloudflare Pages (via Wrangler docker run)
+        run: |
+          docker buildx build -t local/${PAGES_PROJECT_NAME}-service:latest -f Dockerfile .
+          docker run --rm \
+            -e CLOUDFLARE_ACCOUNT_ID=$CLOUDFLARE_ACCOUNT_ID \
+            -e CLOUDFLARE_API_TOKEN=$CLOUDFLARE_API_TOKEN \
+            -e CLOUDFLARE_ZONE_ID=$CLOUDFLARE_ZONE_ID \
+            local/${PAGES_PROJECT_NAME}-service:latest \
+            ./deploy.sh ${PAGES_PROJECT_NAME} ${ENV_CODE}
+        env:
+          PAGES_PROJECT_NAME: ${{ inputs.project }}-${{ inputs.service_name }}-${{ env.ENV_CODE }}
+
+      # Notify success
+      - name: Notify Slack (Success)
+        if: ${{ success() }}
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,commit,author,ref,workflow,pullRequest
+        env:
+          SLACK_WEBHOOK_URL: ${{ inputs.slack_webhook_url }}
+
+      # Notify fail + mention user
+      - name: Notify Slack (Fail)
+        if: ${{ failure() }}
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,commit,author,ref,workflow,pullRequest
+          text: "❌ Build failed! ${{ inputs.slack_mentions }} please check 🚨"
+        env:
+          SLACK_WEBHOOK_URL: ${{ inputs.slack_webhook_url }}

--- a/.github/workflows/docs-develop.yml
+++ b/.github/workflows/docs-develop.yml
@@ -1,0 +1,27 @@
+name: CI/CD Develop Docs
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  call-ci-cd:
+    name: CI/CD Develop Docs
+    uses: ./.github/workflows/ci-cd.yml
+    with:
+      project: "ttsopenai"
+      service_name: "docs"
+      env_code: "dev"
+      environment: "Develop"
+      git_branch: "develop"
+      aws_role_arn: ${{ vars.AWS_ROLE_ARN }}
+      aws_region: ${{ vars.AWS_REGION }}
+      slack_mentions: ${{ vars.SLACK_MENTIONS }}
+      slack_webhook_url: ${{ vars.SLACK_WEBHOOK_URL }}
+    secrets: inherit

--- a/.github/workflows/docs-production.yml
+++ b/.github/workflows/docs-production.yml
@@ -1,0 +1,26 @@
+name: CI/CD Production Docs
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  call-ci-cd:
+    uses: ./.github/workflows/ci-cd.yml
+    with:
+      project: "ttsopenai"
+      service_name: "docs"
+      env_code: "prod"
+      environment: "Production"
+      git_branch: "main"
+      aws_role_arn: ${{ vars.AWS_ROLE_ARN }}
+      aws_region: ${{ vars.AWS_REGION }}
+      slack_mentions: ${{ vars.SLACK_MENTIONS }}
+      slack_webhook_url: ${{ vars.SLACK_WEBHOOK_URL }}
+    secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,8 @@ FROM base
 ENV PORT=$PORT
 ENV NODE_ENV=production
 
-COPY --from=build /src/.output ./
+RUN npm install -g wrangler
+
+COPY --from=build /src/.output ./.output
+COPY --from=build /src/deploy.sh ./deploy.sh
+RUN chmod +x ./deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -euf -o pipefail
+
+PAGES_PROJECT_NAME=$1
+ENV_CODE=$2
+
+if [[ -z $CLOUDFLARE_API_TOKEN || -z $CLOUDFLARE_ACCOUNT_ID || -z $CLOUDFLARE_ZONE_ID ]]; then
+    echo "[ERROR] Missing required environment variables."
+    echo "[ERROR] Missing env CLOUDFLARE_API_TOKEN|CLOUDFLARE_ACCOUNT_ID|CLOUDFLARE_ZONE_ID"
+    exit 1
+fi
+
+if [[ $ENV_CODE == "dev" || $ENV_CODE == "stg" ]]; then
+    echo "[SYS] Setup basic authentication for $ENV_CODE"
+    mkdir -p .output/public/functions
+    cat <<'EOF' > .output/public/functions/_middleware.js
+export const onRequest = async (context) => {
+    const { request, env } = context;
+    const auth = request.headers.get('Authorization');
+    const [user, pass] = [env.BASIC_USER, env.BASIC_PASS];
+    if (!auth || !isValid(auth, user, pass)) {
+      return new Response('Unauthorized', {
+        status: 401,
+        headers: { 'WWW-Authenticate': 'Basic realm="Secure Area"' },
+      });
+    }
+    return await context.next();
+};
+
+const isValid = (auth, user, pass) => {
+    const [scheme, encoded] = auth.split(' ');
+    if (scheme !== 'Basic') return false;
+    const decoded = atob(encoded).split(':');
+    return decoded[0] === user && decoded[1] === pass;
+};
+EOF
+fi
+
+echo "[Cloudflare Pages] wrangler pages deploying to ${PAGES_PROJECT_NAME}"
+wrangler pages deploy .output/public --project-name=${PAGES_PROJECT_NAME}
+
+# Invalidate the cache of a CloudFlare Cache.
+echo "[Cloudflare CDN] Invalidating cache..."
+curl https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache \
+    -H 'Content-Type: application/json' \
+    -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+    -d '{"purge_everything":true}'
+echo "[Cloudflare CDN] Cache invalidated with purge_everything=true"


### PR DESCRIPTION
- Add reusable ci-cd.yml workflow for build and deploy to Cloudflare Pages
- Add docs-develop.yml workflow triggered on develop branch pushes
- Add docs-production.yml workflow triggered on main branch pushes
- Update Dockerfile to install wrangler and copy deployment script
- Add deploy.sh script for Cloudflare Pages deployment with basic auth setup
- Configure AWS OIDC authentication and SSM parameter loading for environment variables
- Add Slack notifications for build success and failure with optional mentions
- Support environment-specific deployments (dev, stg, prod) with concurrency control