### PR TITLE
ci(cd-workflow): update environment variable naming for deployment

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -106,8 +106,7 @@ jobs:
             local/${PAGES_PROJECT_NAME}-service:latest \
             ./deploy.sh ${PAGES_PROJECT_NAME} ${ENV_CODE}
         env:
-          PAGES_PROJECT_NAME: ${{ inputs.project }}-${{ inputs.service_name }}-${{ env.ENV_CODE }}
-
+          PAGES_PROJECT_NAME: frontend-${{ inputs.service_name }}-tts-${{ env.ENV_CODE }}
       # Notify success
       - name: Notify Slack (Success)
         if: ${{ success() }}


### PR DESCRIPTION
- Change PAGES_PROJECT_NAME to use hardcoded 'frontend' prefix instead of dynamic project input
- Update service name variable reference to 'tts' for consistency
- Remove trailing blank line for cleaner formatting
- Simplifies deployment configuration by standardizing project naming convention